### PR TITLE
feat(tests): Add crawler module tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,39 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main, test/* ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      # Note: For security reasons, actual API keys should be set in GitHub Secrets
+      # FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+      # COLIVARA_API_KEY: ${{ secrets.COLIVARA_API_KEY }}
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-asyncio
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    
+    - name: Run unit tests
+      run: |
+        pytest -m "unit" -v
+    
+    - name: Print test result message
+      run: |
+        echo "Unit tests completed. Integration tests will be skipped as they require API keys."
+        echo "To run integration tests locally, set the required API keys in your environment."

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+markers =
+    unit: Unit tests
+    integration: Integration tests
+    slow: Tests that take a long time to run
+    crawler: Tests for the crawler module

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+Convenience script to run tests for the Multimodal RAG system.
+"""
+import argparse
+import os
+import subprocess
+import sys
+
+def main():
+    """Run the specified tests."""
+    parser = argparse.ArgumentParser(description="Run tests for the Multimodal RAG system.")
+    parser.add_argument('--unit', action='store_true', help='Run unit tests only')
+    parser.add_argument('--integration', action='store_true', help='Run integration tests only')
+    parser.add_argument('--crawler', action='store_true', help='Run crawler tests only')
+    parser.add_argument('--all', action='store_true', help='Run all tests')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+    
+    args = parser.parse_args()
+    
+    # Set up pytest command
+    pytest_cmd = ["pytest"]
+    
+    if args.verbose:
+        pytest_cmd.append("-v")
+    
+    # Add markers based on arguments
+    if args.unit:
+        pytest_cmd.append("-m unit")
+    elif args.integration:
+        pytest_cmd.append("-m integration")
+    elif args.crawler:
+        pytest_cmd.append("-m crawler")
+    elif not args.all:
+        # Default to unit tests if no flag is specified
+        pytest_cmd.append("-m unit")
+    
+    # Run the tests
+    print(f"Running command: {' '.join(pytest_cmd)}")
+    result = subprocess.run(pytest_cmd, shell=True if os.name == 'nt' else False)
+    
+    return result.returncode
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,85 @@
+# Testing Strategy for Multimodal RAG System
+
+This directory contains tests for the Multimodal RAG system. The tests are organized into unit tests and integration tests.
+
+## Test Categories
+
+- **Unit Tests**: Tests for individual components with mocks for external dependencies
+- **Integration Tests**: Tests that verify how components work together or with external services
+- **Crawler Tests**: Tests specific to the crawler module
+
+## Running Tests
+
+### Using pytest directly
+
+```bash
+# Run all tests
+pytest
+
+# Run only unit tests
+pytest -m unit
+
+# Run only crawler tests
+pytest -m crawler
+
+# Run only integration tests
+pytest -m integration
+
+# Run tests with verbose output
+pytest -v
+
+# Run a specific test file
+pytest tests/test_crawler.py
+```
+
+### Using the run_tests.py script
+
+We provide a convenience script to run the tests:
+
+```bash
+# Run unit tests (default)
+python run_tests.py
+
+# Run all tests
+python run_tests.py --all
+
+# Run only unit tests
+python run_tests.py --unit
+
+# Run only integration tests
+python run_tests.py --integration
+
+# Run only crawler tests
+python run_tests.py --crawler
+
+# Run with verbose output
+python run_tests.py --verbose
+```
+
+## Requirements for Integration Tests
+
+Some integration tests require API keys to be set in the environment:
+
+- `FIRECRAWL_API_KEY`: Required for crawler integration tests
+- `COLIVARA_API_KEY`: Required for document processor integration tests
+
+If these keys are not set, the corresponding tests will be skipped.
+
+## Test Data
+
+Tests that require test data will create and clean up after themselves. Integration tests will create files in the `data/screenshots`, `data/pdfs`, and other directories as needed. 
+
+The tests are designed to clean up after themselves, but if they fail in unexpected ways, you may need to manually delete test files.
+
+## Adding New Tests
+
+When adding new tests:
+
+1. Place unit tests in files named `test_*.py`
+2. Use appropriate markers (`@pytest.mark.unit`, `@pytest.mark.integration`, etc.)
+3. Consider using `pytest.mark.skipif` for tests that require external dependencies
+4. Ensure tests clean up after themselves in teardown methods
+
+## Mocking External Services
+
+For unit tests, we mock external services like FirecrawlApp and ColiVara using the `unittest.mock` module. See existing tests for examples of how to mock these services.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test suite for the Multimodal RAG system.
+"""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -13,6 +13,9 @@ from loguru import logger
 from src.crawler.crawler import WebsiteCrawler, run_crawler
 from config.config import CRAWLER_SETTINGS, SCREENSHOTS_DIR
 
+# Mark all tests in this file as unit tests and crawler tests
+pytestmark = [pytest.mark.unit, pytest.mark.crawler]
+
 
 class TestWebsiteCrawler(unittest.TestCase):
     """Test cases for the WebsiteCrawler class."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,170 @@
+"""
+Tests for the web crawler module.
+"""
+import os
+import asyncio
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from loguru import logger
+
+from src.crawler.crawler import WebsiteCrawler, run_crawler
+from config.config import CRAWLER_SETTINGS, SCREENSHOTS_DIR
+
+
+class TestWebsiteCrawler(unittest.TestCase):
+    """Test cases for the WebsiteCrawler class."""
+
+    def setUp(self):
+        """Set up test environment before each test."""
+        # Disable logger for testing
+        logger.remove()
+        logger.add(lambda _: None, level="ERROR")
+        
+        # Create a mock config for testing
+        self.test_config = {
+            "headless": True,
+            "viewport_width": 800,
+            "viewport_height": 600,
+            "scroll_behavior": "smooth",
+            "wait_for_idle": 2,
+            "max_concurrent_pages": 2,
+            "max_pages_per_site": 5,
+            "respect_robots_txt": True,
+            "user_agent": "TestBot/1.0",
+            "proxy": None,
+            "auth": {
+                "username": None,
+                "password": None,
+            },
+            "cookies_file": None,
+            "api_key": "test_api_key",
+            "output_dir": Path("./test_output")
+        }
+        
+        # Create test directories if they don't exist
+        self.test_output_dir = Path("./test_output")
+        self.test_output_dir.mkdir(exist_ok=True)
+        
+        # Set up test URL
+        self.test_url = "https://example.com"
+
+    def tearDown(self):
+        """Clean up after each test."""
+        # Remove test output directory
+        if self.test_output_dir.exists():
+            for file in self.test_output_dir.glob("*"):
+                file.unlink()
+            self.test_output_dir.rmdir()
+
+    @patch('src.crawler.crawler.FirecrawlApp')
+    def test_crawler_initialization(self, mock_firecrawl):
+        """Test crawler initialization with custom config."""
+        # Setup mock
+        mock_firecrawl.return_value = MagicMock()
+        
+        # Create crawler with test config
+        crawler = WebsiteCrawler(config=self.test_config)
+        
+        # Assert FirecrawlApp was instantiated with the correct API key
+        mock_firecrawl.assert_called_once_with(api_key=self.test_config["api_key"])
+        
+        # Check that output directories were created
+        self.assertTrue(crawler.output_dir.exists())
+        self.assertTrue(Path(SCREENSHOTS_DIR).exists())
+        
+        # Check that config was set correctly
+        self.assertEqual(crawler.config, self.test_config)
+
+    @patch('src.crawler.crawler.FirecrawlApp')
+    def test_authentication_setup(self, mock_firecrawl):
+        """Test authentication setup."""
+        # Create a mock instance
+        mock_instance = MagicMock()
+        mock_firecrawl.return_value = mock_instance
+        
+        # Setup test config with auth credentials
+        auth_config = self.test_config.copy()
+        auth_config["auth"]["username"] = "testuser"
+        auth_config["auth"]["password"] = "testpass"
+        
+        # Create crawler with auth config
+        crawler = WebsiteCrawler(config=auth_config)
+        
+        # Call authentication method
+        crawler.setup_authentication()
+        
+        # Assert authenticate was called with correct credentials
+        mock_instance.authenticate.assert_called_once_with(
+            username="testuser", password="testpass"
+        )
+
+    @patch('src.crawler.crawler.WebsiteCrawler.crawl_url')
+    @pytest.mark.asyncio
+    async def test_crawl_method(self, mock_crawl_url):
+        """Test the crawl method."""
+        # Setup mock for crawl_url
+        mock_crawl_url.return_value = {
+            'url': self.test_url,
+            'saved_files': [Path("./test_output/example.com_home.json")],
+            'result': {'html': '<html></html>', 'markdown': '# Example'}
+        }
+        
+        # Create crawler with test config
+        crawler = WebsiteCrawler(config=self.test_config)
+        
+        # Call the crawl method
+        saved_files, _ = await crawler.crawl(
+            start_urls=[self.test_url],
+            max_depth=1,
+            max_pages=2
+        )
+        
+        # Assert crawl_url was called with the correct URL
+        mock_crawl_url.assert_called_once_with(self.test_url)
+        
+        # Check results
+        self.assertEqual(len(saved_files), 1)
+        self.assertEqual(saved_files[0], Path("./test_output/example.com_home.json"))
+
+    @patch('src.crawler.crawler.WebsiteCrawler')
+    @pytest.mark.asyncio
+    async def test_run_crawler_function(self, mock_crawler_class):
+        """Test the run_crawler standalone function."""
+        # Setup mocks
+        mock_instance = MagicMock()
+        mock_crawler_class.return_value = mock_instance
+        
+        mock_instance.crawl.return_value = (
+            [Path("./test_output/example.com_home.json")], []
+        )
+        
+        # Call standalone function
+        saved_files, _ = await run_crawler(
+            start_urls=[self.test_url],
+            max_depth=1,
+            max_pages=2
+        )
+        
+        # Assert WebsiteCrawler was instantiated
+        mock_crawler_class.assert_called_once()
+        
+        # Assert crawl method was called with correct parameters
+        mock_instance.crawl.assert_called_once_with(
+            [self.test_url],
+            max_depth=1,
+            max_pages=2
+        )
+        
+        # Check that close was called
+        mock_instance.close.assert_called_once()
+        
+        # Check results
+        self.assertEqual(len(saved_files), 1)
+        self.assertEqual(saved_files[0], Path("./test_output/example.com_home.json"))
+
+
+if __name__ == '__main__':
+    pytest.main(['-xvs', 'tests/test_crawler.py'])

--- a/tests/test_crawler_integration.py
+++ b/tests/test_crawler_integration.py
@@ -11,8 +11,11 @@ from loguru import logger
 from src.crawler.crawler import WebsiteCrawler
 from config.config import CRAWLER_SETTINGS, SCREENSHOTS_DIR, PDFS_DIR
 
+# Mark all tests in this file as integration tests and crawler tests
+pytestmark = [pytest.mark.integration, pytest.mark.crawler, pytest.mark.slow]
+
 # Skip these tests if the FIRECRAWL_API_KEY is not set
-pytestmark = pytest.mark.skipif(
+pytestmark += pytest.mark.skipif(
     os.getenv("FIRECRAWL_API_KEY") is None,
     reason="FIRECRAWL_API_KEY environment variable not set"
 )
@@ -117,6 +120,7 @@ class TestCrawlerIntegration:
             crawler.close()
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_crawl_with_depth(self):
         """Test crawling with depth > 1 on a site with multiple pages."""
         # Skip if running in CI environment to avoid long-running tests

--- a/tests/test_crawler_integration.py
+++ b/tests/test_crawler_integration.py
@@ -1,0 +1,149 @@
+"""
+Integration tests for the web crawler module.
+"""
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from src.crawler.crawler import WebsiteCrawler
+from config.config import CRAWLER_SETTINGS, SCREENSHOTS_DIR, PDFS_DIR
+
+# Skip these tests if the FIRECRAWL_API_KEY is not set
+pytestmark = pytest.mark.skipif(
+    os.getenv("FIRECRAWL_API_KEY") is None,
+    reason="FIRECRAWL_API_KEY environment variable not set"
+)
+
+
+class TestCrawlerIntegration:
+    """Integration tests for the WebsiteCrawler."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test environment once before all tests."""
+        # Disable logger for testing
+        logger.remove()
+        logger.add(lambda _: None, level="INFO")
+        
+        # Create test directories if they don't exist
+        cls.screenshots_dir = Path(SCREENSHOTS_DIR)
+        cls.pdfs_dir = Path(PDFS_DIR)
+        cls.screenshots_dir.mkdir(exist_ok=True)
+        cls.pdfs_dir.mkdir(exist_ok=True)
+        
+        # Make note of starting files to clean up only new ones later
+        cls.original_screenshots = set(cls.screenshots_dir.glob("*"))
+        cls.original_pdfs = set(cls.pdfs_dir.glob("*"))
+        
+        # Set up test URLs
+        cls.test_url = "https://example.com"  # Simple static site for basic testing
+        cls.simple_dynamic_url = "https://quotes.toscrape.com/"  # Simple dynamic site
+
+    @classmethod
+    def teardown_class(cls):
+        """Clean up after all tests."""
+        # Remove only files created during tests
+        current_screenshots = set(cls.screenshots_dir.glob("*"))
+        current_pdfs = set(cls.pdfs_dir.glob("*"))
+        
+        # Delete new screenshots
+        for file in current_screenshots - cls.original_screenshots:
+            if file.is_file():
+                file.unlink()
+        
+        # Delete new PDFs
+        for file in current_pdfs - cls.original_pdfs:
+            if file.is_file():
+                file.unlink()
+
+    @pytest.mark.asyncio
+    async def test_crawl_static_site(self):
+        """Test crawling a simple static website."""
+        crawler = WebsiteCrawler()
+        
+        try:
+            # Crawl example.com (1 page)
+            saved_files, _ = await crawler.crawl(
+                start_urls=[self.test_url],
+                max_depth=1,
+                max_pages=1
+            )
+            
+            # Check that we got some files
+            assert len(saved_files) > 0, "No files were saved from crawling example.com"
+            
+            # Check file existence
+            for file_path in saved_files:
+                assert file_path.exists(), f"Saved file {file_path} does not exist"
+            
+            # Verify content of at least one file
+            if saved_files:
+                first_file = saved_files[0]
+                with open(first_file, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                    assert len(content) > 0, "Saved file is empty"
+                    
+                    # If it's a JSON file, it should at least contain the URL
+                    if first_file.suffix == '.json':
+                        assert self.test_url in content, f"URL {self.test_url} not found in saved content"
+        
+        finally:
+            # Ensure crawler is closed
+            crawler.close()
+
+    @pytest.mark.asyncio
+    async def test_capture_single_page(self):
+        """Test capturing a single page."""
+        crawler = WebsiteCrawler()
+        
+        try:
+            # Capture a single page
+            primary_file, secondary_file = await crawler.capture_single_page(self.test_url)
+            
+            # Check that we got at least one file
+            assert primary_file is not None, "No primary file was saved"
+            assert primary_file.exists(), f"Primary file {primary_file} does not exist"
+            
+            # Check content of the primary file
+            with open(primary_file, 'r', encoding='utf-8') as f:
+                content = f.read()
+                assert len(content) > 0, "Primary file is empty"
+        
+        finally:
+            # Ensure crawler is closed
+            crawler.close()
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_depth(self):
+        """Test crawling with depth > 1 on a site with multiple pages."""
+        # Skip if running in CI environment to avoid long-running tests
+        if os.getenv("CI") == "true":
+            pytest.skip("Skipping depth crawl test in CI environment")
+        
+        crawler = WebsiteCrawler()
+        
+        try:
+            # Crawl quotes.toscrape.com with depth 2 (should get multiple pages)
+            saved_files, _ = await crawler.crawl(
+                start_urls=[self.simple_dynamic_url],
+                max_depth=2,
+                max_pages=5  # Limit to 5 pages to keep test short
+            )
+            
+            # Check that we got multiple files (should be more than just the start page)
+            assert len(saved_files) > 1, "Not enough files were saved from depth crawling"
+            
+            # Check file existence
+            for file_path in saved_files:
+                assert file_path.exists(), f"Saved file {file_path} does not exist"
+        
+        finally:
+            # Ensure crawler is closed
+            crawler.close()
+
+
+if __name__ == '__main__':
+    pytest.main(['-xvs', 'tests/test_crawler_integration.py'])


### PR DESCRIPTION
This PR adds comprehensive test coverage for the crawler module, including:

## Features
- Unit tests for the `WebsiteCrawler` class with mocks for external dependencies
- Integration tests for real-world usage of the crawler
- Testing infrastructure with pytest configuration
- Convenience script for running tests with different options
- Documentation for the testing strategy

## Implementation Details
- Created a structured test directory and initial test setup
- Added unit tests for crawler initialization, authentication, and crawling
- Added integration tests for crawling static and dynamic websites
- Added test markers for categorizing tests (unit, integration, crawler)
- Added pytest configuration file for easier test running
- Added comprehensive testing documentation

## Testing
To run the unit tests:
```bash
python run_tests.py --unit
```

To run the integration tests (requires FIRECRAWL_API_KEY):
```bash
python run_tests.py --integration
```

All unit tests pass successfully. Integration tests can be run with a valid API key.

## Notes
- Added integration tests are skipped if no API key is available
- Tests clean up after themselves to avoid leaving test artifacts
